### PR TITLE
Fixed a wrong call to otrs.SetPermissions.pl for OTRS Framework 5.

### DIFF
--- a/InstallTestsystem.pl
+++ b/InstallTestsystem.pl
@@ -278,9 +278,15 @@ print STDERR "############################################\n";
 # setting permissions
 print STDERR "--- Setting permissions...\n";
 print STDERR "############################################\n";
-system(
-    "sudo perl $InstallDir/bin/otrs.SetPermissions.pl --otrs-user=$Config{PermissionsOTRSUser} --web-user=$Config{PermissionsWebUser} --otrs-group=$Config{PermissionsOTRSGroup} --web-group=$Config{PermissionsWebGroup} --not-root $InstallDir"
-);
+if ( $OTRSMajorVersion >= 5 ) {
+    system(
+        "sudo perl $InstallDir/bin/otrs.SetPermissions.pl --otrs-user=$Config{PermissionsOTRSUser} --web-group=$Config{PermissionsWebGroup} $InstallDir"
+    );
+} else {
+    system(
+        "sudo perl $InstallDir/bin/otrs.SetPermissions.pl --otrs-user=$Config{PermissionsOTRSUser} --web-user=$Config{PermissionsWebUser} --otrs-group=$Config{PermissionsOTRSGroup} --web-group=$Config{PermissionsWebGroup} --not-root $InstallDir"
+    );
+}
 print STDERR "############################################\n";
 
 # Deleting Cache
@@ -306,9 +312,15 @@ system("rm $InstallDir/bin/FillTestsystem.pl");
 # setting permissions
 print STDERR "--- Setting permissions again (just to be sure)...\n";
 print STDERR "############################################\n";
-system(
-    "sudo perl $InstallDir/bin/otrs.SetPermissions.pl --otrs-user=$Config{PermissionsOTRSUser} --web-user=$Config{PermissionsWebUser} --otrs-group=$Config{PermissionsOTRSGroup} --web-group=$Config{PermissionsWebGroup} --not-root $InstallDir"
-);
+if ( $OTRSMajorVersion >= 5 ) {
+    system(
+        "sudo perl $InstallDir/bin/otrs.SetPermissions.pl --otrs-user=$Config{PermissionsOTRSUser} --web-group=$Config{PermissionsWebGroup} $InstallDir"
+    );
+} else {
+    system(
+        "sudo perl $InstallDir/bin/otrs.SetPermissions.pl --otrs-user=$Config{PermissionsOTRSUser} --web-user=$Config{PermissionsWebUser} --otrs-group=$Config{PermissionsOTRSGroup} --web-group=$Config{PermissionsWebGroup} --not-root $InstallDir"
+    );
+}
 print STDERR "############################################\n";
 
 print STDERR "Finished.\n";


### PR DESCRIPTION
That script has only been partially updated for OTRS 5's new bin commands. `otrs.SetPermissions.pl` was called with Framework 4 style arguments. The PR updates the code to call `otrs.SetPermissions.pl` with appropriate arguments depending on Framework used.