### PR TITLE
Fixed error handling for database actions in case of table column name which contains "error"

### DIFF
--- a/lib/Console/Command/Module/Database/Install.pm
+++ b/lib/Console/Command/Module/Database/Install.pm
@@ -85,7 +85,7 @@ sub Run {
 
     $Self->Print("$ErrorMessage\n");
 
-    if ( !$Success || $ErrorMessage =~ m{error}i ) {
+    if ( !$Success || $ErrorMessage =~ m{ERROR\:} ) {
         $Self->PrintError("Couldn't run database install correctly from $Module");
         return $Self->ExitCodeError();
     }

--- a/lib/Console/Command/Module/Database/Uninstall.pm
+++ b/lib/Console/Command/Module/Database/Uninstall.pm
@@ -85,7 +85,7 @@ sub Run {
 
     $Self->Print("$ErrorMessage\n");
 
-    if ( !$Success || $ErrorMessage =~ m{error}i ) {
+    if ( !$Success || $ErrorMessage =~ m{ERROR\:} ) {
         $Self->PrintError("Couldn't run database uninstall correctly from $Module");
         return $Self->ExitCodeError();
     }

--- a/lib/Console/Command/Module/Database/Upgrade.pm
+++ b/lib/Console/Command/Module/Database/Upgrade.pm
@@ -85,7 +85,7 @@ sub Run {
 
     $Self->Print("$ErrorMessage\n");
 
-    if ( !$Success || $ErrorMessage =~ m{error}i ) {
+    if ( !$Success || $ErrorMessage =~ m{ERROR\:} ) {
         $Self->PrintError("Couldn't run database update correctly from $Module");
         return $Self->ExitCodeError();
     }


### PR DESCRIPTION
Hi,
if the table creation contains a column name called e.g. **error_message** then the output will contain it too:

```
Notice: CREATE TABLE abc_import (
...
    error_message TEXT NULL,
...
)
```

The database install was correctly but the script will return a error because of the regex
```
Error: Couldn't run database install correctly from ...
```

I improved the regex to prevent this case.

Best regards,
Rolf