### PR TITLE
Handle version on database upgrades

### DIFF
--- a/lib/Console/BaseModule.pm
+++ b/lib/Console/BaseModule.pm
@@ -180,6 +180,29 @@ sub DatabaseActionHandler {
 
     return 1 if !$Structure{$StructureKey}->{ $Param{Type} };
 
+    if ( $Param{Version} ) {
+        my %RelevantStructure;
+
+        my $CheckVersion = sprintf "%d%03d%03d", split /\./, $Param{Version};
+
+        for my $Type ( qw/pre post/ ) {
+
+            PART:
+            for my $Part ( @{ $Structure{$StructureKey}->{$Type} || [] } ) {
+                next PART if !$Part->{Version};
+
+                my $PartVersion = sprintf "%d%03d%03d", split /\./, $Part->{Version};
+
+                next PART if $CheckVersion > $PartVersion;
+
+                push @{ $RelevantStructure{$Type} }, $Part;
+            }
+        }
+
+        $Structure{$StructureKey} = \%RelevantStructure;
+    }
+
+
     my $Success = $CommonObject{PackageObject}->_Database(
         Database => $Structure{$StructureKey}->{ $Param{Type} },
     );

--- a/lib/Console/Command/Module/Database/Upgrade.pm
+++ b/lib/Console/Command/Module/Database/Upgrade.pm
@@ -37,6 +37,14 @@ sub Configure {
         ValueRegex  => qr/.*/smx,
     );
 
+    $Self->AddOption(
+        Name        => 'version',
+        Description => "Minimum version for database upgrade statements",
+        Required    => 0,
+        HasValue    => 1,
+        ValueRegex  => qr/\d+\.\d{1,3}\.\d{1,3}/smx,
+    );
+
     return;
 }
 
@@ -87,9 +95,10 @@ sub Run {
 
         for my $Type (@Types) {
             $Success = $Self->DatabaseActionHandler(
-                Module => $Module,
-                Action => 'Upgrade',
-                Type   => $Type,
+                Module  => $Module,
+                Action  => 'Upgrade',
+                Type    => $Type,
+                Version => $Self->GetOption('version'),
             );
         }
     }


### PR DESCRIPTION
This is really useful when you have lots of database upgrade statements in the sopm and you only want to execute
the latest statements. With the version option you can define the minimum version of upgrade statements
to be executed.