### PR TITLE
Added XML::Simple to cpanfile

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,3 +5,4 @@ requires 'Term::ANSIColor';
 requires 'String::Similarity';
 requires 'XMLRPC::Lite';
 requires 'Path::Tiny';
+requires 'XML::Simple';


### PR DESCRIPTION
Beim Ausprobieren von bin/otrs.ModuleTools.pl hat Perl wegen XML::Simple gemeckert.